### PR TITLE
Feature add dynamic data to home page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "prop-types": "^15.8.1",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
+        "react-paginate": "^8.1.2",
         "react-redux": "^7.2.6",
         "react-scripts": "5.0.0",
         "web-vitals": "^2.1.4"
@@ -14240,6 +14241,17 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
+    "node_modules/react-paginate": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/react-paginate/-/react-paginate-8.1.2.tgz",
+      "integrity": "sha512-buBkBiN9J8gvZYwYNixlTGRmWOC5C6+tH2XHTN8B5qGkRPOSYFkAqxhWUnxSVAeLKxpVZGPya/gOL2eJQNZGvg==",
+      "dependencies": {
+        "prop-types": "^15.6.1"
+      },
+      "peerDependencies": {
+        "react": "^16 || ^17"
+      }
+    },
     "node_modules/react-redux": {
       "version": "7.2.6",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.6.tgz",
@@ -28273,6 +28285,14 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+    },
+    "react-paginate": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/react-paginate/-/react-paginate-8.1.2.tgz",
+      "integrity": "sha512-buBkBiN9J8gvZYwYNixlTGRmWOC5C6+tH2XHTN8B5qGkRPOSYFkAqxhWUnxSVAeLKxpVZGPya/gOL2eJQNZGvg==",
+      "requires": {
+        "prop-types": "^15.6.1"
+      }
     },
     "react-redux": {
       "version": "7.2.6",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "prop-types": "^15.8.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
+    "react-paginate": "^8.1.2",
     "react-redux": "^7.2.6",
     "react-scripts": "5.0.0",
     "web-vitals": "^2.1.4"

--- a/src/components/ModelCarDetails/modelCarDetails.css
+++ b/src/components/ModelCarDetails/modelCarDetails.css
@@ -1,11 +1,14 @@
 .estimateDiv {
-  display: flex;
-  flex-direction: column;
-  width: 90%;
-  margin: 10px auto;
-  border: 1px solid black;
+  display: grid;
+  grid-template-columns: 1fr;
+  margin: auto;
+  /* border: 1px solid black; */
   border-radius: 10px;
   padding: 25px 5px;
+}
+
+.differentColour {
+  background-color: rgb(57, 96, 168);
 }
 
 .imageLogoContainer {
@@ -16,7 +19,6 @@
 
 .logoImage {
   width: 100%;
-  height: 100%;
 }
 
 .carModelDescriptionContainer {
@@ -25,7 +27,7 @@
 
 .carModelDescriptionText {
   font-family: Montserrat, serif;
-  font-size: 30px;
+  font-size: 20px;
   margin: 10px;
   text-align: right;
 }

--- a/src/components/ModelCarDetails/modelCarDetails.css
+++ b/src/components/ModelCarDetails/modelCarDetails.css
@@ -2,7 +2,6 @@
   display: grid;
   grid-template-columns: 1fr;
   margin: auto;
-  /* border: 1px solid black; */
   border-radius: 10px;
   padding: 25px 5px;
 }

--- a/src/components/ModelCarDetails/modelCarDetails.js
+++ b/src/components/ModelCarDetails/modelCarDetails.js
@@ -3,10 +3,12 @@ import { Fragment } from 'react';
 import PropTypes from 'prop-types';
 
 const ModelCarDetails = (props) => {
-  const { vehicleLogoSrc, carModelName, numberOfModelsAvailable } = props;
+  const {
+    vehicleLogoSrc, carModelName, numberOfModelsAvailable, colour,
+  } = props;
   return (
     <>
-      <div className="estimateDiv">
+      <div className={colour ? 'estimateDiv differentColour' : 'estimateDiv'}>
         <div className="imageLogoContainer">
           <img alt="vehicle logo" className="logoImage" src={vehicleLogoSrc} />
         </div>
@@ -25,6 +27,11 @@ ModelCarDetails.propTypes = {
   vehicleLogoSrc: PropTypes.string.isRequired,
   carModelName: PropTypes.string.isRequired,
   numberOfModelsAvailable: PropTypes.number.isRequired,
+  colour: PropTypes.string,
+};
+
+ModelCarDetails.defaultProps = {
+  colour: '',
 };
 
 export default ModelCarDetails;

--- a/src/pages/home/home.css
+++ b/src/pages/home/home.css
@@ -20,3 +20,19 @@
   display: grid;
   grid-template-columns: 1fr 1fr;
 }
+
+.pagination {
+  list-style: none;
+}
+
+.page-item {
+  text-align: center;
+  border: 1px solid black;
+  width: 80px;
+  background-color: rgb(202, 218, 231);
+  cursor: pointer;
+}
+
+.active {
+  background-color: rgb(74, 74, 146);
+}

--- a/src/pages/home/home.js
+++ b/src/pages/home/home.js
@@ -1,57 +1,111 @@
-import { Fragment, useEffect } from 'react';
+import { Fragment, useEffect, useState } from 'react';
 import './home.css';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
+import ReactPaginate from 'react-paginate';
 import ModelCarDetails from '../../components/ModelCarDetails/modelCarDetails';
 import { fetchCarModels } from '../../redux/reduxSlices/carModelSlice';
 
+const CarModelList = ({ carModelList }) => {
+  let keyData = 1;
+  console.log(carModelList);
+  return (
+    <>
+      {carModelList
+        && carModelList.map((item, index) => {
+          keyData += 1;
+          if (index % 1.5 === 0) {
+            return (
+              <ModelCarDetails
+                colour="different"
+                key={keyData}
+                vehicleLogoSrc="https://c8.alamy.com/comp/D12RG7/logo-of-the-make-alfa-romeo-of-the-italian-car-manufacturer-fiat-group-D12RG7.jpg"
+                carModelName={item.data.attributes.name}
+                numberOfModelsAvailable={item.data.attributes.number_of_models}
+              />
+            );
+          }
+          return (
+            <ModelCarDetails
+              key={keyData}
+              vehicleLogoSrc="https://c8.alamy.com/comp/D12RG7/logo-of-the-make-alfa-romeo-of-the-italian-car-manufacturer-fiat-group-D12RG7.jpg"
+              carModelName={item.data.attributes.name}
+              numberOfModelsAvailable={item.data.attributes.number_of_models}
+            />
+          );
+        })}
+    </>
+  );
+};
+
+function PaginatedItems({ itemsPerPage }) {
+  const [currentItems, setCurrentItems] = useState([]);
+  const [pageCount, setPageCount] = useState(0);
+  const [itemOffset, setItemOffset] = useState(0);
+
+  const carModels = useSelector((state) => state.carModels);
+  console.log(carModels);
+
+  useEffect(() => {
+    console.log('pagnation useEffect');
+    // let {carModelsDestruct} = carModels.carModels;
+    console.log(carModels.carModels);
+    // Fetch items from another resources.
+    const endOffset = itemOffset + itemsPerPage;
+    console.log(`Loading items from ${itemOffset} to ${endOffset}`);
+    if (carModels.carModels.length !== 0) {
+      console.log(currentItems);
+      setCurrentItems(carModels.carModels.slice(itemOffset, endOffset));
+      console.log(currentItems);
+      setPageCount(Math.ceil(carModels.carModels.length / itemsPerPage));
+    }
+  }, [itemOffset, itemsPerPage, carModels]);
+
+  // Invoke when user click to request another page.
+  const handlePageClick = (event) => {
+    const newOffset = (event.selected * itemsPerPage) % carModels.carModels.length;
+    console.log(
+      `User requested page number ${event.selected}, which is offset ${newOffset}`,
+    );
+    setItemOffset(newOffset);
+  };
+
+  return (
+    <>
+      <CarModelList carModelList={currentItems} />
+      <ReactPaginate
+        breakLabel="..."
+        nextLabel="-->"
+        previousLabel="<--"
+        onPageChange={handlePageClick}
+        pageCount={pageCount}
+        renderOnZeroPageCount={null}
+        pageRangeDisplayed={3}
+        marginPagesDisplayed={2}
+        pageClassName="page-item"
+        pageLinkClassName="page-link"
+        previousClassName="page-item"
+        previousLinkClassName="page-link"
+        nextClassName="page-item"
+        breakClassName="page-item"
+        breakLinkClassName="page-link"
+        containerClassName="pagination"
+        activeClassName="active"
+      />
+    </>
+  );
+}
+
 const Home = () => {
-  // const carModels = useSelector((state) => state);
   const dispatch = useDispatch();
   useEffect(() => {
     dispatch(fetchCarModels());
   }, []);
-
-  let keyData = 1;
-  const ModelArrayData = [{
-    vehicleLogoSrc: 'https://c8.alamy.com/comp/D12RG7/logo-of-the-make-alfa-romeo-of-the-italian-car-manufacturer-fiat-group-D12RG7.jpg',
-    carModelName: 'Alfa Romeo',
-    numberOfModelsAvailable: 567,
-  }, {
-    vehicleLogoSrc: 'https://c8.alamy.com/comp/D12RG7/logo-of-the-make-alfa-romeo-of-the-italian-car-manufacturer-fiat-group-D12RG7.jpg',
-    carModelName: 'BMW',
-    numberOfModelsAvailable: 1567,
-  }, {
-    vehicleLogoSrc: 'https://c8.alamy.com/comp/D12RG7/logo-of-the-make-alfa-romeo-of-the-italian-car-manufacturer-fiat-group-D12RG7.jpg',
-    carModelName: 'Benz',
-    numberOfModelsAvailable: 5567,
-  }, {
-    vehicleLogoSrc: 'https://c8.alamy.com/comp/D12RG7/logo-of-the-make-alfa-romeo-of-the-italian-car-manufacturer-fiat-group-D12RG7.jpg',
-    carModelName: 'Lambo',
-    numberOfModelsAvailable: 55667,
-  },
-  {
-    vehicleLogoSrc: 'https://c8.alamy.com/comp/D12RG7/logo-of-the-make-alfa-romeo-of-the-italian-car-manufacturer-fiat-group-D12RG7.jpg',
-    carModelName: 'Nissan',
-    numberOfModelsAvailable: 6856,
-  }];
   return (
     <>
       <h1 className="mainHeaderText"> VEHICLE CARBON ESTIMATE STATS PER 100KM</h1>
       <p className="subMainHeaderText">STATS By Models</p>
       <div className="mainEstimateGrid">
-        {
-            ModelArrayData.map((element) => {
-              keyData += 1;
-              return (
-                <ModelCarDetails
-                  key={keyData}
-                  vehicleLogoSrc={element.vehicleLogoSrc}
-                  carModelName={element.carModelName}
-                  numberOfModelsAvailable={element.numberOfModelsAvailable}
-                />
-              );
-            })
-        }
+        <PaginatedItems itemsPerPage={10} />
       </div>
     </>
   );

--- a/src/pages/home/home.js
+++ b/src/pages/home/home.js
@@ -2,12 +2,12 @@ import { Fragment, useEffect, useState } from 'react';
 import './home.css';
 import { useDispatch, useSelector } from 'react-redux';
 import ReactPaginate from 'react-paginate';
+import PropTypes from 'prop-types';
 import ModelCarDetails from '../../components/ModelCarDetails/modelCarDetails';
 import { fetchCarModels } from '../../redux/reduxSlices/carModelSlice';
 
 const CarModelList = ({ carModelList }) => {
   let keyData = 1;
-  console.log(carModelList);
   return (
     <>
       {carModelList
@@ -37,25 +37,22 @@ const CarModelList = ({ carModelList }) => {
   );
 };
 
+CarModelList.propTypes = {
+  carModelList: PropTypes.shape.isRequired,
+};
+
 function PaginatedItems({ itemsPerPage }) {
   const [currentItems, setCurrentItems] = useState([]);
   const [pageCount, setPageCount] = useState(0);
   const [itemOffset, setItemOffset] = useState(0);
 
   const carModels = useSelector((state) => state.carModels);
-  console.log(carModels);
 
   useEffect(() => {
-    console.log('pagnation useEffect');
-    // let {carModelsDestruct} = carModels.carModels;
-    console.log(carModels.carModels);
-    // Fetch items from another resources.
+    // Fetch items from other resources.
     const endOffset = itemOffset + itemsPerPage;
-    console.log(`Loading items from ${itemOffset} to ${endOffset}`);
     if (carModels.carModels.length !== 0) {
-      console.log(currentItems);
       setCurrentItems(carModels.carModels.slice(itemOffset, endOffset));
-      console.log(currentItems);
       setPageCount(Math.ceil(carModels.carModels.length / itemsPerPage));
     }
   }, [itemOffset, itemsPerPage, carModels]);
@@ -63,9 +60,6 @@ function PaginatedItems({ itemsPerPage }) {
   // Invoke when user click to request another page.
   const handlePageClick = (event) => {
     const newOffset = (event.selected * itemsPerPage) % carModels.carModels.length;
-    console.log(
-      `User requested page number ${event.selected}, which is offset ${newOffset}`,
-    );
     setItemOffset(newOffset);
   };
 
@@ -94,6 +88,10 @@ function PaginatedItems({ itemsPerPage }) {
     </>
   );
 }
+
+PaginatedItems.propTypes = {
+  itemsPerPage: PropTypes.shape.isRequired,
+};
 
 const Home = () => {
   const dispatch = useDispatch();

--- a/src/redux/reduxSlices/carModelSlice.js
+++ b/src/redux/reduxSlices/carModelSlice.js
@@ -27,7 +27,13 @@ const initialState = {
 const carModelSlice = createSlice({
   name: 'carModels',
   initialState,
-  extraReducers: { [fetchCarModels.fulfilled]: (state, action) => [...action.payload] },
+  // extraReducers: { [fetchCarModels.fulfilled]: (state, action) => [...action.payload] }
+
+  extraReducers: (builder) => {
+    builder
+      .addCase(fetchCarModels.fulfilled, (state, action) => (
+        { ...state, carModels: action.payload }));
+  },
 });
 
 export default carModelSlice.reducer;


### PR DESCRIPTION
## What this PR does:
  - Implement Dynamic data from the API to be displayed on home page load 

## How to test it
  - clone the repository by running\
      `git clone https://github.com/Beardless-sheik/Economics-Data-Webapp.git`
  - navigate to the root folder\
 - Install packages\
      `npm install`
  - Run application using: 
      `npm start`

## Details 
- Add react-paginate library to paginate the carModel options on the Homepage
- Display home page categories of cars 
- Add styling for Home Page
- Add an extra reducer to pass the result from the asyncChunk function that pulls data
- Update each ModelCarDetail component with dynamic data
- Update ModelCarDetail component styling